### PR TITLE
Create main workflow to automatically deploy every monday at 6:00 CEST

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: Merge Dev into Production
+
+on:
+  schedule:
+    - cron: '0 4 * * 1' # 4:00 UTC is 6:00 CEST
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  merge_dev_to_production:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge Dev into Production
+        run: |
+          git fetch origin
+          git checkout production
+          git merge origin/dev --no-edit
+          git push origin production


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of merging the `dev` branch into the `production` branch. The workflow is scheduled to run weekly and can also be triggered manually.

Key changes include:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R1-R26): Added a new workflow named "Merge Dev into Production" that runs on a schedule and can be manually triggered. It includes steps for checking out the repository, setting up Git, and performing the merge from `dev` to `production`.