### PR TITLE
Create main.yml (deploy to server)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,52 @@
+name: Deploy to Server
+
+on:
+  push:
+    branches:
+      - QA
+      - Dev
+      - Production
+  pull_request:
+    branches:
+      - QA
+      - Dev
+      - Production
+
+jobs:
+  deploy:
+    name: Deploy to Self-Hosted Server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Docker Image
+        run: |
+          echo "Building Docker image for branch ${{ github.ref_name }}"
+          docker build -t cmb-${{ github.ref_name }}:latest .
+
+      - name: Connect and Deploy
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          script: |
+            echo "Deploying branch ${{ github.ref_name }}"
+            
+            # Stop the old container
+            docker stop cmb-${{ github.ref_name }}:latest || true
+            docker rm cmb-${{ github.ref_name }}:latest || true
+            
+            # Copy the built image from the CI runner to the server
+            docker save cmb-${{ github.ref_name }}:latest | bzip2 | sshpass -p ${{ secrets.SSH_PASSWORD }} ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} 'docker load < bzcat > /tmp/cmb-${{ github.ref_name }}.tar.bz2'
+            
+            # Run the new container with restart policy and expose port 8088
+            docker run -d --name cmb-${{ github.ref_name }}:latest \
+              --restart always \
+              -p 8088:8088 \
+              cmb-${{ github.ref_name }}:latest


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying to a self-hosted server. The workflow is triggered by pushes and pull requests to the `QA`, `Dev`, and `Production` branches. The key changes include setting up Docker, building Docker images, and deploying them to the server.

Deployment automation:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R1-R52): Added a new workflow named "Deploy to Server" that triggers on pushes and pull requests to specified branches (`QA`, `Dev`, `Production`). It includes steps for checking out the code, setting up Docker Buildx, building Docker images, and deploying them to a self-hosted server using SSH.